### PR TITLE
Fix name of the `CommandRegistry` built-in service

### DIFF
--- a/docs/advanced/creating-services.md
+++ b/docs/advanced/creating-services.md
@@ -8,7 +8,7 @@ A `load` method will be called the first time that service is requested.
 Built-in Services:
 
 - Config (registered as `config`)
-- CommandRegistry (registered as `command_registry`)
+- CommandRegistry (registered as `commandRegistry`)
 - OutputHandler (registered as `printer`)
 
 Registering a service:


### PR DESCRIPTION
`CommandRegistry` built-in service is registered as `commandRegistry` instead of `command_registry` here https://github.com/minicli/minicli/blob/main/src/App.php#L63