### PR TITLE
Fix function name on creating-services.md

### DIFF
--- a/docs/advanced/creating-services.md
+++ b/docs/advanced/creating-services.md
@@ -19,7 +19,7 @@ Registering a service:
 $my_service = new MyService();
 
 $app = new App();
-$app->registerService('my-service', $my_service);
+$app->addService('my-service', $my_service);
 ```
 
 This service will be available from controllers via magic `__get` method:

--- a/docs/advanced/creating-services.md
+++ b/docs/advanced/creating-services.md
@@ -1,6 +1,6 @@
 # Creating and Registering Services
 
-The `App` class is a container that supports registering new services through the `registerService` method. You can create your own service by implementing the `ServiceInterface` interface.
+The `App` class is a container that supports registering new services through the `addService` method. You can create your own service by implementing the `ServiceInterface` interface.
 
 Services are *lazily loaded*, which means they'll only be loaded when requested from within the application.
 A `load` method will be called the first time that service is requested.


### PR DESCRIPTION
The documentation page `https://docs.minicli.dev/en/latest/advanced/creating-services/` is showing:
```<?php
...
$my_service = new MyService();

$app = new App();
$app->registerService('my-service', $my_service);
```
However, `registerService` seems to be an unexistent function instead of `addService`