### PR TITLE
Fix broken logo URL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # About
 <p align="center">
-<img src="https://minicli.dev/images/minicli_logo_term_pink.png" align="center" alt="logo" title="Minicli logo" alt="Minicli Logo" width="200">
+<img src="/landing/images/minicli_logo_term_pink.png" align="center" alt="logo" title="Minicli logo" alt="Minicli Logo" width="200">
 </p>
 
 <p align="center">


### PR DESCRIPTION
The previous logo URL in the docs/about section was broken for some reason. To fix this, I updated the image path to a relative URL.

<img width="873" alt="image" src="https://user-images.githubusercontent.com/43740952/236914540-624c76ac-0d08-4e6d-917b-2498d9efee45.png">
