### PR TITLE
fix: updating composer bin readme

### DIFF
--- a/docs/advanced/composer-bin.md
+++ b/docs/advanced/composer-bin.md
@@ -25,6 +25,12 @@ require $root_app . '/vendor/autoload.php';
 $app = new App();
 //code continues...
 ```
+If you are running your minicli app as a dependency of a larger project. e.g. A Laravel Project, set the app root as the location of your CLI like so:
+
+```php
+$app = new App(appRoot: dirname(__DIR__, 1));
+```
+
 
 With your script ready, edit the project's `composer.json` file to include `minicli` in your `bin` section:
 


### PR DESCRIPTION
Great job on Minicli, always my go-to when building clis in php. So I was building a CLI that lints my laravel project then I followed the docs on [Setting up a Minicli app as Composer bin command](https://docs.minicli.dev/en/latest/advanced/composer-bin/). After installing my laravel project I kept getting this error:

```bash
 Error: Call to undefined method Illuminate\Container\Container::storagePath() in /Users/nelwhix/Documents/open-source/sandbox/vendor/laravel/framework/src/Illuminate/Foundation/helpers.php on line 875

Call Stack:
    0.0008     618672   1. {main}() /Users/nelwhix/Documents/open-source/sandbox/vendor/bin/standards:0
    0.0017     623144   2. include('/Users/nelwhix/Documents/open-source/sandbox/vendor/treblle/standards/bin/standards') /Users/nelwhix/Documents/open-source/sandbox/vendor/bin/standards:119
    0.0273    4133912   3. Minicli\App->__construct($config = ???, $signature = ???, $appRoot = ???) /Users/nelwhix/Documents/open-source/sandbox/vendor/treblle/standards/bin/standards:19
    0.0278    4158856   4. Minicli\App->boot($config = [], $signature = './minicli help') /Users/nelwhix/Documents/open-source/sandbox/vendor/minicli/minicli/src/App.php:51
    0.0278    4158856   5. Minicli\App->loadConfig($config = [], $signature = './minicli help') /Users/nelwhix/Documents/open-source/sandbox/vendor/minicli/minicli/src/App.php:61
    0.0284    4164136   6. load_config($defaultConfig = ['app_path' => '/Users/nelwhix/Documents/open-source/sandbox/Command', 'theme' => '', 'debug' => TRUE], $configPath = '/Users/nelwhix/Documents/open-source/sandbox/config') /Users/nelwhix/Documents/open-source/sandbox/vendor/minicli/minicli/src/App.php:274
    0.0377    5097168   7. include('/Users/nelwhix/Documents/open-source/sandbox/config/cache.php') /Users/nelwhix/Documents/open-source/sandbox/vendor/minicli/minicli/src/helpers.php:15
    0.0377    5098296   8. storage_path($path = 'framework/cache/data') /Users/nelwhix/Documents/open-source/sandbox/config/cache.php:56
```

I read through the call stack and saw that this was because while the cli was booting up it was trying to read config from my laravel config directory instead of it's own config. so I am adding this section to the readme.

There is one bug with this approach though. The `@minicli/command-help` that comes bundled with the minicli application template does not work when I set this app root in this way. I will make another PR in the future to fix, if this is accepted. Thanks!